### PR TITLE
fby3.5: hd:Modify APML alert ISR

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_isr.c
@@ -365,6 +365,22 @@ void IST_PLTRST()
 	reset_tsi_status();
 }
 
+#define FATAL_ERROR_DELAY_MSECOND 500
+typedef struct {
+	struct k_work_delayable work;
+	uint8_t ras_status;
+} fatal_error_work_info;
+
+static void send_apml_alert(struct k_work *work)
+{
+	fatal_error_work_info *work_info = CONTAINER_OF(work, fatal_error_work_info, work);
+	if (get_DC_status()) {
+		LOG_INF("Send apml alert to bmc.");
+		send_apml_alert_to_bmc(work_info->ras_status);
+	}
+	SAFE_FREE(work_info);
+}
+
 void ISR_APML_ALERT()
 {
 	uint8_t ras_status;
@@ -374,6 +390,13 @@ void ISR_APML_ALERT()
 	}
 
 	if (ras_status & 0x0F) {
+		fatal_error_work_info *delay_wrok = malloc(sizeof(fatal_error_work_info));
+		if (delay_wrok == NULL) {
+			LOG_ERR("Failed to allocate delay_job.");
+			return;
+		}
+		memset(delay_wrok, 0, sizeof(fatal_error_work_info));
+
 		LOG_INF("Fatal error happened, ras_status 0x%x.", ras_status);
 		fatal_error_happened();
 
@@ -388,6 +411,8 @@ void ISR_APML_ALERT()
 		if ((status & 0x02) && (apml_write_byte(APML_BUS, SB_RMI_ADDR, SBRMI_STATUS, 0x02)))
 			LOG_ERR("Failed to clear SwAlertSts.");
 
-		send_apml_alert_to_bmc(ras_status);
+		delay_wrok->ras_status = ras_status;
+		k_work_init_delayable(&(delay_wrok->work), send_apml_alert);
+		k_work_schedule(&(delay_wrok->work), K_MSEC(FATAL_ERROR_DELAY_MSECOND));
 	}
 }


### PR DESCRIPTION
Summary:
- After injecting pmic critical error, fatal error will be detected and OS will shut dwon.
It causes unnecessary ADDC process, because the system is shut down and BMC cannot dump date from apml.
Solve it by waitting 500ms and then check DC status. If DC status is off, skip the ADDC process.

Test Plan:
- Build Code: PASS
- ADDC inject test: PASS