### PR TITLE
fby3.5: hd: Support apml recovery

### DIFF
--- a/common/service/apml/apml.h
+++ b/common/service/apml/apml.h
@@ -20,6 +20,8 @@
 #define APML_SUCCESS 0
 #define APML_ERROR 1
 
+#define RMI_SOFT_RESET_BIT BIT(0)
+
 enum APML_MSG_TYPE {
 	APML_MSG_TYPE_MAILBOX,
 	APML_MSG_TYPE_CPUID,
@@ -41,6 +43,7 @@ enum SBTSI_REGISTER {
 	SBTSI_CONFIG = 0x03,
 	SBTSI_UPDATE_RATE = 0x04,
 	SBTSI_HIGH_TEMP_INTEGER_THRESHOLD = 0x07,
+	SBTSI_CONFIG_WRITE = 0x09,
 	SBTSI_CPU_TEMP_DEC = 0x10,
 };
 
@@ -52,6 +55,7 @@ enum SBRMI_MAILBOX_ERR_CODE {
 };
 
 enum SBRMI_REGISTER {
+	SBRMI_REVISION = 0x00,
 	SBRMI_STATUS = 0x02,
 	SBRMI_OUTBANDMSG_INST0 = 0x30,
 	SBRMI_OUTBANDMSG_INST1 = 0x31,
@@ -129,5 +133,6 @@ uint8_t get_apml_response_by_index(apml_msg *msg, uint8_t index);
 uint8_t apml_read(apml_msg *msg);
 void apml_init();
 void fatal_error_happened();
+void apml_recovery();
 
 #endif

--- a/meta-facebook/yv35-hd/src/platform/plat_apml.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_apml.h
@@ -25,6 +25,7 @@
 #define SB_TSI_ADDR 0x4C
 #define TSI_HIGH_TEMP_THRESHOLD 0x5F
 #define TSI_TEMP_ALERT_UPDATE_RATE 0x0A
+#define PLAT_SBRMI_REVISION 0x20
 
 typedef struct _addc_trigger_info {
 	uint8_t event_version;

--- a/meta-facebook/yv35-hd/src/platform/plat_init.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_init.c
@@ -74,6 +74,7 @@ void pal_set_sys_status()
 	set_DC_on_delayed_status();
 	set_post_status(FM_BIOS_POST_CMPLT_BIC_N);
 	if (get_post_status()) {
+		apml_recovery();
 		set_tsi_threshold();
 		read_cpuid();
 	}


### PR DESCRIPTION
Summary:
- Check SBRMI version when platform initialization and APML access fails. Recover SBRMI if read fails or the read value is unexpected.
- Fixed issue: If previous APML write terminated without i2c stop signal, subsequent APML read value would be wrong. (can be reproduced by BIC reset stress)

Test Plan:
- Build code: PASS
- BIC reset stress: 5000 loops pass.